### PR TITLE
Allow longer commands such as entering long wifi passwords

### DIFF
--- a/sketches/ig-os/cli.h
+++ b/sketches/ig-os/cli.h
@@ -108,7 +108,7 @@ const char* helpNetwork =
 class Cli
   : public StreamCmd< 2, /* _NumCommandSets    */
                      48, /* _MaxCommands       */
-                     32, /* _CommandBufferSize */
+                     128, /* _CommandBufferSize */
                       8> /* _MaxCommandSize    */
 {
 private:


### PR DESCRIPTION
My wifi passwords are quite a bit longer than 32 characters, so the complete command is even longer. 128 characters should do, though.